### PR TITLE
Introduced IEntries

### DIFF
--- a/src/Schematic/Entries.php
+++ b/src/Schematic/Entries.php
@@ -2,11 +2,10 @@
 
 namespace Schematic;
 
-use Countable;
 use Iterator;
 
 
-class Entries implements Countable, Iterator
+class Entries implements Iterator, IEntries
 {
 
 	/**
@@ -60,7 +59,7 @@ class Entries implements Countable, Iterator
 
 		$itemType = $this->itemsType;
 
-		return $this->cachedItems[$key] = new $itemType(current($this->items));
+		return $this->cachedItems[$key] = new $itemType(current($this->items), get_called_class());
 	}
 
 

--- a/src/Schematic/Entry.php
+++ b/src/Schematic/Entry.php
@@ -16,20 +16,31 @@ class Entry
 	/**
 	 * @var array
 	 */
-	private $data;
+	private $initializedAssociations = [];
 
 	/**
 	 * @var array
 	 */
-	private $initializedAssociations = [];
+	private $data;
+
+	/**
+	 * @var string
+	 */
+	private $entriesClass;
 
 
 	/**
 	 * @param array $data
+	 * @param string $entriesClass
 	 */
-	public function __construct(array $data)
+	public function __construct(array $data, $entriesClass = Entries::class)
 	{
+		if (!is_a($entriesClass, IEntries::class, TRUE)) {
+			throw new InvalidArgumentException('Entries class must implement IEntries interface.');
+		}
+
 		$this->data = $data;
+		$this->entriesClass = $entriesClass;
 	}
 
 
@@ -51,9 +62,11 @@ class Entry
 
 			$associationType = $this->associationTypes[$name];
 
+			$entriesClass = $this->entriesClass;
+
 			return $this->data[$name] = is_array($associationType) ?
-				new Entries($this->data[$name], reset($associationType)) :
-				new $associationType($this->data[$name]);
+				new $entriesClass($this->data[$name], reset($associationType)) :
+				new $associationType($this->data[$name], $this->entriesClass);
 		}
 	}
 

--- a/src/Schematic/IEntries.php
+++ b/src/Schematic/IEntries.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Schematic;
+
+use Countable;
+use Traversable;
+
+
+interface IEntries extends Traversable, Countable
+{
+
+	/**
+	 * @return Entry[]
+	 */
+	public function toArray();
+
+}

--- a/tests/SchematicTests/EntryTest.phpt
+++ b/tests/SchematicTests/EntryTest.phpt
@@ -38,13 +38,49 @@ class EntryTest extends TestCase
 
 	public function testEntiresAccess()
 	{
-		$order = new Order(['orderItems' => [
-			['id' => 1],
-			['id' => 2],
-		]]);
+		$order = new Order([
+			'customer' => [
+				'id' => 100,
+			],
+			'orderItems' => [
+				['id' => 1],
+				['id' => 2],
+			],
+		]);
 
 		Assert::type(Entries::class, $order->orderItems);
 		Assert::count(2, $order->orderItems);
+
+		Assert::type(Customer::class, $order->customer);
+		Assert::same(100, $order->customer->id);
+	}
+
+
+	public function testEntriesClass()
+	{
+		$order = new Order([
+			'orderItems' => [
+				[
+					'id' => 1,
+					'tags' => [
+						['name' => 'first-order'],
+						['name' => 'premium'],
+					],
+				],
+				[
+					'id' => 2,
+					'tags' => [],
+				],
+			],
+		], CustomEntries::class);
+
+		Assert::type(CustomEntries::class, $order->orderItems);
+
+		$orderItems = $order->orderItems->toArray();
+		/** @var OrderItem $firstOrderItem */
+		$firstOrderItem = reset($orderItems);
+
+		Assert::type(CustomEntries::class, $firstOrderItem->tags);
 	}
 
 }

--- a/tests/SchematicTests/entries.php
+++ b/tests/SchematicTests/entries.php
@@ -2,7 +2,9 @@
 
 namespace SchematicTests;
 
+use Schematic\Entries;
 use Schematic\Entry;
+use Schematic\IEntries;
 
 
 /**
@@ -15,7 +17,8 @@ abstract class Identified extends Entry
 
 
 /**
- * @property-read OrderItem[] $orderItems
+ * @property-read Customer|NULL $customer
+ * @property-read IEntries|OrderItem[] $orderItems
  * @property-read string $note
  * @property-read bool $approved
  */
@@ -23,13 +26,42 @@ class Order extends Identified
 {
 
 	protected $associationTypes = [
+		'customer' => Customer::class,
 		'orderItems' => [OrderItem::class],
 	];
 
 }
 
 
+/**
+ * @property-read Tag[] $tags
+ */
 class OrderItem extends Identified
+{
+
+	protected $associationTypes = [
+		'tags' => [Tag::class],
+	];
+
+}
+
+
+class Customer extends Identified
+{
+
+}
+
+
+/**
+ * @property string $name
+ */
+class Tag extends Entry
+{
+
+}
+
+
+class CustomEntries extends Entries
 {
 
 }


### PR DESCRIPTION
What do you think about this idea?

@stekycz @matej21

Note, how custom entries class is propagated in nested values: https://github.com/Tharos/Schematic/compare/entriesInterface?expand=1#diff-4121e2f0e5aa8ebeee2ce79e9089958cR83

If you want to use custom `IEntries` by default instead of typing it every time, all you have to do is to create a basic `Entry` like this:

```php
class Entry extends \Schematic\Entries
{

	/**
	 * @param array $data
	 * @param string $entriesClass
	 */
	public function __construct(array $data, $entriesClass = LazyEntries::class)
	{
		parent::__construct($data, $entriesClass);
	}

}
```

Note overriden default value of `$entriesClass`…