### PR TITLE
Added: minimal required php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,9 @@
 			"email": "v.kohout@gmail.com"
 		}
 	],
+	"require": {
+		"php": ">=5.6"
+	},
 	"require-dev": {
 		"nette/tester": "~1.6"
 	},


### PR DESCRIPTION
Added: minimal required php version

php 5.5 not support https://github.com/Tharos/Schematic/blob/develop/src/Schematic/Entries.php#L131 (...$keys)