### PR TITLE
Fix compatibility with PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,10 @@
 		}
 	],
 	"require": {
-		"php": ">=5.6"
+		"php": ">=7.4"
 	},
 	"require-dev": {
-		"nette/tester": "~1.6"
+		"nette/tester": "~2.4"
 	},
 	"autoload": {
 		"psr-0": {

--- a/src/Schematic/Entries.php
+++ b/src/Schematic/Entries.php
@@ -51,13 +51,14 @@ class Entries implements Iterator, IEntries
 	/**
 	 * @return Entry
 	 */
+	#[\ReturnTypeWillChange]
 	public function current()
 	{
 		return $this->get($this->key());
 	}
 
 
-	public function next()
+	public function next(): void
 	{
 		next($this->items);
 	}
@@ -66,31 +67,26 @@ class Entries implements Iterator, IEntries
 	/**
 	 * @return mixed
 	 */
+	#[\ReturnTypeWillChange]
 	public function key()
 	{
 		return key($this->items);
 	}
 
 
-	/**
-	 * @return bool
-	 */
-	public function valid()
+	public function valid(): bool
 	{
 		return array_key_exists(key($this->items), $this->items);
 	}
 
 
-	public function rewind()
+	public function rewind(): void
 	{
 		reset($this->items);
 	}
 
 
-	/**
-	 * @return int
-	 */
-	public function count()
+	public function count(): int
 	{
 		return count($this->items);
 	}

--- a/src/Schematic/Entry.php
+++ b/src/Schematic/Entry.php
@@ -182,7 +182,8 @@ class Entry implements JsonSerializable
 			self::parseAssociations($calledClass);
 		}
 	}
-	
+
+	#[\ReturnTypeWillChange]
 	public function jsonSerialize()
 	{
 		return $this->data;


### PR DESCRIPTION
PHP 8.1 requires return types in interface implementations,
in this case Iterator and JsonSerializable.

Adding #[\ReturnTypeWillChange] keeps backwards compatibility
with older versions of PHP (required 'mixed' arrived in 8.1).

See https://wiki.php.net/rfc/internal_method_return_types for
more details.

nette/tester had to be updated because explode() no longer
accepts null as a second argument.